### PR TITLE
Flag `--namespace` now implies `--only-scope=namespace`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Get all resources...
   ```
   This flag understands typical human-readable durations such as `1m` or `1y1d1h1m1s`.
 
-- ... in some namespace
+- ... in the default namespace
   ```bash
-  ketall --only-scope=namespace --namespace=my-namespace
+  ketall --namespace=default
   ```
 
 - ... using list of cached server resources

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,8 +59,8 @@ More on https://github.com/corneliusweig/ketall/blob/v1.0.2/doc/USAGE.md#usage
   Get all cluster level resources
   $ ketall --only-scope=cluster
 
-  Get all resources in a particular namespace
-  $ ketall --only-scope=namespace --namespace=<some>
+  Get all resources in the default namespace
+  $ ketall --namespace=default
 
   Some options can also be configured in the config file 'ketall'
 `

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -42,9 +42,9 @@ Get all resources...
   kubectl get-all --only-scope=cluster
   ```
 
-- ... in some namespace
+- ... in the default namespace
   ```bash
-  kubectl get-all --only-scope=namespace --namespace=my-namespace
+  kubectl get-all --namespace=default
   ```
 
 - ... using list of cached server resources

--- a/pkg/ketall/client/client.go
+++ b/pkg/ketall/client/client.go
@@ -196,7 +196,7 @@ func fetchResourcesIncremental(flags resource.RESTClientGetter, rs ...groupResou
 func getResourceScope(scope string) (skipCluster, skipNamespace bool, err error) {
 	switch scope {
 	case "":
-		skipCluster = false
+		skipCluster = viper.GetString(constants.FlagNamespace) != ""
 		skipNamespace = false
 	case "namespace":
 		skipCluster = true


### PR DESCRIPTION
Before, the effect of `--namespace` was to exclude namespace resources from namespaces other than the given one, because all cluster-scoped resources were still printed. Now, `--namespace` will only show namespaced resources from the given namespace.