### PR TITLE
Support flag `--field-selector`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,6 +93,7 @@ func init() {
 	rootCmd.Flags().StringVar(&ketallOptions.Scope, constants.FlagScope, "", "only resources with scope cluster|namespace")
 	rootCmd.Flags().StringVar(&ketallOptions.Since, constants.FlagSince, "", "only resources younger than given age")
 	rootCmd.Flags().StringVarP(&ketallOptions.Selector, constants.FlagSelector, "l", "", "selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	rootCmd.Flags().StringVar(&ketallOptions.FieldSelector, constants.FlagFieldSelector, "", "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The common field queries for all types are metadata.name and metadata.namespace.")
 	rootCmd.Flags().StringSliceVar(&ketallOptions.Exclusions, constants.FlagExclude, []string{"events"}, "filter by resource name (plural form or short name)")
 
 	ketallOptions.GenericCliFlags.AddFlags(rootCmd.Flags())

--- a/pkg/ketall/client/client.go
+++ b/pkg/ketall/client/client.go
@@ -67,8 +67,10 @@ func GetAllServerResources(flags *genericclioptions.ConfigFlags) (runtime.Object
 func getExclusions() []string {
 	exclusions := viper.GetStringSlice(constants.FlagExclude)
 
-	// This is a workaround for a k8s bug where componentstatus is reported even though the label selector does not apply
-	if selector := viper.GetString(constants.FlagSelector); selector != "" {
+	// This is a workaround for a k8s bug where componentstatus is reported even though the selector does not apply
+	selector := viper.GetString(constants.FlagSelector)
+	fieldSelector := viper.GetString(constants.FlagFieldSelector)
+	if selector != "" || fieldSelector != "" {
 		exclusions = append(exclusions, "componentstatuses")
 	}
 
@@ -163,10 +165,13 @@ func fetchResourcesBulk(flags resource.RESTClientGetter, resourceTypes ...groupR
 		request.AllNamespaces(true)
 	}
 
-	if selector := viper.GetString(constants.FlagSelector); selector != "" {
-		request.LabelSelectorParam(selector)
-	} else {
+	selector := viper.GetString(constants.FlagSelector)
+	fieldSelector := viper.GetString(constants.FlagFieldSelector)
+	if selector == "" && fieldSelector == "" {
 		request.SelectAllParam(true)
+	} else {
+		request.LabelSelectorParam(selector)
+		request.FieldSelectorParam(fieldSelector)
 	}
 
 	return request.Do().Object()

--- a/pkg/ketall/constants/constants.go
+++ b/pkg/ketall/constants/constants.go
@@ -21,10 +21,11 @@ import "github.com/sirupsen/logrus"
 const (
 	DefaultLogLevel = logrus.WarnLevel
 
-	FlagExclude   = "exclude"
-	FlagNamespace = "namespace"
-	FlagScope     = "only-scope"
-	FlagSince     = "since"
-	FlagUseCache  = "use-cache"
-	FlagSelector  = "selector"
+	FlagExclude       = "exclude"
+	FlagNamespace     = "namespace"
+	FlagScope         = "only-scope"
+	FlagSince         = "since"
+	FlagUseCache      = "use-cache"
+	FlagSelector      = "selector"
+	FlagFieldSelector = "field-selector"
 )

--- a/pkg/ketall/options/options.go
+++ b/pkg/ketall/options/options.go
@@ -34,6 +34,7 @@ type KetallOptions struct {
 	Scope           string
 	Since           string
 	Selector        string
+	FieldSelector   string
 	Exclusions      []string
 	Streams         *genericclioptions.IOStreams
 }


### PR DESCRIPTION
`kubectl get` supports this flag, so it makes sense to also support it, even though its usefulness is limited