### PR TITLE
Enable repeatable builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,16 @@ CHECKSUMS += $(BUNDLE).sha256
 
 VERSION_PACKAGE := $(REPOPATH)/pkg/ketall/version
 
+DATE_FMT = %Y-%m-%dT%H:%M:%SZ
+ifdef SOURCE_DATE_EPOCH
+    # GNU and BSD date require different options for a fixed date
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null)
+else
+    BUILD_DATE ?= $(shell date "+$(DATE_FMT)")
+endif
 GO_LDFLAGS :="-s -w
 GO_LDFLAGS += -X $(VERSION_PACKAGE).version=$(VERSION)
-GO_LDFLAGS += -X $(VERSION_PACKAGE).buildDate=$(shell date +'%Y-%m-%dT%H:%M:%SZ')
+GO_LDFLAGS += -X $(VERSION_PACKAGE).buildDate=$(BUILD_DATE)
 GO_LDFLAGS += -X $(VERSION_PACKAGE).gitCommit=$(COMMIT)
 GO_LDFLAGS +="
 


### PR DESCRIPTION
See https://reproducible-builds.org/ for why this is good and
https://reproducible-builds.org/specs/source-date-epoch/ for the
definition of this variable. This date call works with various variants of date.