### PR TITLE
Show `kubectl get-all` in the help text for krew builds

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,3 +1,5 @@
+// +build !getall
+
 /*
 Copyright 2019 Cornelius Weig
 

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -1,0 +1,56 @@
+// +build !getall
+
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/corneliusweig/ketall/pkg/ketall/options"
+)
+
+func TestMainCompletionCommand(t *testing.T) {
+	tests := [][]string{
+		{"ketall", "completion", "zsh"},
+		{"ketall", "completion", "bash"},
+	}
+
+	for _, testargs := range tests {
+		t.Run(testargs[2], func(t *testing.T) {
+			origOpts := ketallOptions
+			newOpts, _, stdout, stderr := options.NewTestTestCmdOptions()
+
+			defer func(args []string) {
+				os.Args = args
+				ketallOptions = origOpts
+			}(os.Args)
+			os.Args = testargs
+			ketallOptions = newOpts
+
+			err := Execute()
+
+			assert.NoError(t, err)
+			assert.NotEmpty(t, stdout.String())
+			assert.Empty(t, stderr.String())
+		})
+
+	}
+}

--- a/cmd/internal/cmdname_ketall.go
+++ b/cmd/internal/cmdname_ketall.go
@@ -1,0 +1,25 @@
+// +build !getall
+
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+const CommandName = "ketall"
+
+func HelpTextMapName(text string) string {
+	return text
+}

--- a/cmd/internal/cmdname_krew.go
+++ b/cmd/internal/cmdname_krew.go
@@ -1,0 +1,30 @@
+// +build getall
+
+/*
+Copyright 2019 Cornelius Weig
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import "strings"
+
+const CommandName = "get-all"
+
+func HelpTextMapName(text string) string {
+	return strings.NewReplacer(
+		"Ketall", "Kubectl get-all",
+		"$ ketall", "$ kubectl get-all",
+	).Replace(text)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,14 +20,16 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/corneliusweig/ketall/pkg/ketall"
-	"github.com/corneliusweig/ketall/pkg/ketall/constants"
-	"github.com/corneliusweig/ketall/pkg/ketall/options"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/util/homedir"
+
+	"github.com/corneliusweig/ketall/cmd/internal"
+	"github.com/corneliusweig/ketall/pkg/ketall"
+	"github.com/corneliusweig/ketall/pkg/ketall/constants"
+	"github.com/corneliusweig/ketall/pkg/ketall/options"
 )
 
 var (
@@ -47,30 +49,30 @@ More on https://github.com/corneliusweig/ketall/blob/v1.2.0/doc/USAGE.md#usage
 `
 	ketallExamples = `
   Get all resources, excluding events
-  $ ketall
+   $ ketall
 
   Get all resources, including events
-  $ ketall --exclude=
+   $ ketall --exclude=
 
   Get all resources created in the last minute
-  $ ketall --since 1m
+   $ ketall --since 1m
 
   Get all resources in the default namespace
-  $ ketall --namespace=default
+   $ ketall --namespace=default
 
   Get all cluster level resources
-  $ ketall --only-scope=cluster
+   $ ketall --only-scope=cluster
 
   Some options can also be configured in the config file './ketall.yaml' or '~/.kube/ketall.yaml'
 `
 )
 
 var rootCmd = &cobra.Command{
-	Use:     "ketall",
-	Short:   "Like 'kubectl get all', but get _really_ all resources",
-	Long:    ketallLongDescription,
+	Use:     internal.CommandName,
+	Short:   "Like `kubectl get all`, but get _really_ all resources",
+	Long:    internal.HelpTextMapName(ketallLongDescription),
 	Args:    cobra.NoArgs,
-	Example: ketallExamples,
+	Example: internal.HelpTextMapName(ketallExamples),
 	Run: func(cmd *cobra.Command, args []string) {
 		ketall.KetAll(ketallOptions)
 	},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -75,31 +75,3 @@ func TestMainVersionCommand(t *testing.T) {
 	assert.Contains(t, stdout.String(), "ketall:")
 	assert.Empty(t, stderr.String())
 }
-
-func TestMainCompletionCommand(t *testing.T) {
-	tests := [][]string{
-		{"ketall", "completion", "zsh"},
-		{"ketall", "completion", "bash"},
-	}
-
-	for _, testargs := range tests {
-		t.Run(testargs[2], func(t *testing.T) {
-			origOpts := ketallOptions
-			newOpts, _, stdout, stderr := options.NewTestTestCmdOptions()
-
-			defer func(args []string) {
-				os.Args = args
-				ketallOptions = origOpts
-			}(os.Args)
-			os.Args = testargs
-			ketallOptions = newOpts
-
-			err := Execute()
-
-			assert.NoError(t, err)
-			assert.NotEmpty(t, stdout.String())
-			assert.Empty(t, stderr.String())
-		})
-
-	}
-}


### PR DESCRIPTION
Also, disable completion for krew plugin builds, because it is simply not usable for those.