### PR TITLE
[travis] Remove obsolete `GOPROXY` and `GO111MODULE` setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ go:
 env:
   global:
   - GO111MODULE=on
-  - GOPROXY=https://proxy.golang.org
 
 before_install:
 - go mod download

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ os:
 go:
 - 1.13.x
 
-env:
-  global:
-  - GO111MODULE=on
-
 before_install:
 - go mod download
 


### PR DESCRIPTION
The setting just re-iterated the go-1.13 default.

Thanks @ferhatelmas for spotting this!