### PR TITLE
Print flat resource lists to comply with k8s list shape

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -168,6 +168,7 @@ func fetchResourcesBulk(flags resource.RESTClientGetter, resourceTypes ...groupR
 		ResourceTypes(resourceNames...).
 		NamespaceParam(ns).DefaultNamespace().AllNamespaces(ns == "").
 		LabelSelectorParam(selector).FieldSelectorParam(fieldSelector).SelectAllParam(selector == "" && fieldSelector == "").
+		Flatten().
 		Latest()
 
 	return request.Do().Object()


### PR DESCRIPTION
Fix #61