### PR TITLE
Fix shell completion

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,7 +77,8 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() error {
-	rootCmd.SetOutput(ketallOptions.Streams.Out)
+	rootCmd.SetOut(ketallOptions.Streams.Out)
+	rootCmd.SetErr(ketallOptions.Streams.ErrOut)
 	return rootCmd.Execute()
 }
 


### PR DESCRIPTION
Fixes #154

This PR redirects errors to stderr because the shell completion provided by Cobra (specifically the `__complete` command) needs it.

**Before the fix**
```
$ ./ketall <TAB>
completion   -- generate the autocompletion script for the specified shell
help         -- Help about any command
version      -- Print the version information
:4           Completion ended with directive: ShellCompDirectiveNoFileComp
```
**After the fix**
```
$ ./ketall <TAB>
completion   -- generate the autocompletion script for the specified shell
help         -- Help about any command
version      -- Print the version information
```
**To reproduce the problem:**
```
make dev
source <(./ketall completion zsh)
compdef _ketall ketall
./ketall <TAB>
```